### PR TITLE
Add Markdown editor with WebAssembly support and CI configuration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "development" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/index.html
+++ b/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Rust & WASM Markdown Editor</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      display: flex;
+      gap: 20px;
+    }
+
+    textarea,
+    #html-output {
+      width: 50%;
+      height: 90vh;
+      padding: 10px;
+      border: 1px solid #ccc;
+      font-size: 16px;
+      box-sizing: border-box;
+    }
+
+    textarea {
+      resize: none;
+    }
+  </style>
+</head>
+
+<body>
+  <textarea id="markdown-input" placeholder="Type Markdown here..."></textarea>
+  <div id="html-output"></div>
+  <script type="module" src="main.js"></script>
+</body>
+
+</html>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import init, { parse_markdown } from './pkg/wasm_markdown_editor';
+import init, { parse_markdown } from './pkg/wasm_markdown_editor.js';
 
 async function run() {
   // Initialize the WebAssembly module.
@@ -8,7 +8,7 @@ async function run() {
   const htmlOutput = document.getElementById('html-output');
 
   // Set default text
-  const defaultMarkdown = '$ Hello, WebAssembly!\n\nType your **Markdown** here.';
+  const defaultMarkdown = '# Hello, WebAssembly!\n\nType your **Markdown** here.';
   markdownInput.value = defaultMarkdown;
   htmlOutput.innerHTML = parse_markdown(defaultMarkdown);
 

--- a/main.js
+++ b/main.js
@@ -1,0 +1,22 @@
+import init, { parse_markdown } from './pkg/wasm_markdown_editor';
+
+async function run() {
+  // Initialize the WebAssembly module.
+  await init();
+
+  const markdownInput = document.getElementById('markdown-input');
+  const htmlOutput = document.getElementById('html-output');
+
+  // Set default text
+  const defaultMarkdown = '$ Hello, WebAssembly!\n\nType your **Markdown** here.';
+  markdownInput.value = defaultMarkdown;
+  htmlOutput.innerHTML = parse_markdown(defaultMarkdown);
+
+  // Add event listener for real-time updates.
+  markdownInput.addEventListener('input', () => {
+    const htmlText = parse_markdown(markdownInput.value);
+    htmlOutput.innerHTML = htmlText;
+  });
+}
+
+run();


### PR DESCRIPTION
Introduce initial HTML and JavaScript files for a Markdown editor, fix import statements, and set up a CI workflow for Rust projects.